### PR TITLE
Rendering should not escape help_text HTML

### DIFF
--- a/src/template_forms/base.py
+++ b/src/template_forms/base.py
@@ -94,7 +94,7 @@ class TemplateForm(BaseForm):
             'outer_classes': outer_classes,
             'label': force_text(label),
             'field': str(bf),
-            'help_text': force_text(bf.help_text),
+            'help_text': mark_safe(bf.help_text),
             'errors': errors,
             'bf': bf,
         }

--- a/src/template_forms/base.py
+++ b/src/template_forms/base.py
@@ -25,7 +25,9 @@ class TemplateForm(BaseForm):
     label_css_class = None
     field_css_class = None
 
-    error_css_class = None
+    # Additional forms.Form attributes:
+    # - error_css_class
+    # - required_css_class
 
     def format_hidden_error(self, name, error):
         return _('(Hidden field %(name)s) %(error)s') % {
@@ -101,7 +103,8 @@ class TemplateForm(BaseForm):
         classes = []
         if self.field_css_class:
             classes.append(self.field_css_class)
-        if errors and self.error_css_class:
+        # boundfield uses a hasattr check instead of 'is not None'
+        if errors and hasattr(self, 'error_css_class'):
             classes.append(self.error_css_class)
         return classes
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -35,8 +35,23 @@ class GetFieldTemplateNameTests(TestCase):
         self.assertEqual(template_name, 'default.html')
 
     def test_not_set(self):
-
         form = self.NotSet()
         msg = '`NotSet.field_template_map` should be a mapping of widgets to template names.'
         with self.assertRaisesMessage(AssertionError, msg):
             form.get_field_template_name(None)
+
+
+class GetFieldCSSClassesTests(TestCase):
+    def test_error_css_class(self):
+        """
+        This result is "incorrect", but operates in accordance to the behavior
+        of `BoundField`, which will error when the attribute is a `NoneType`.
+        """
+        class Form(TemplateForm, forms.Form):
+            field = forms.CharField()
+            error_css_class = None
+
+        form = Form()
+        bf = form['field']
+
+        self.assertEqual([None], form.get_field_css_classes(bf, 'error'))

--- a/tests/testapp/templates/tests/base_field.html
+++ b/tests/testapp/templates/tests/base_field.html
@@ -1,0 +1,6 @@
+<div class="{{ outer_classes }}">
+    {{ label }}
+    {{ field }}
+    {% for error in errors %}<p class="errors">{{ error }}</p>{% endfor %}
+    {% if help_text %}<p class="helptext">{{ help_text }}</p>{% endif %}
+</div>

--- a/tests/testapp/templates/tests/base_form.html
+++ b/tests/testapp/templates/tests/base_form.html
@@ -1,0 +1,14 @@
+{% if top_errors %}
+<div class="errors">
+    The following errors have occurred:
+    {{ top_errors }}
+</div>
+{% endif %}
+
+{% for field in hidden_output %}
+{{ field }}
+{% endfor %}
+
+{% for field in output %}
+{{ field }}
+{% endfor %}

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
     django111: django>=1.11.0,<2.0
-    django20: django>=2.0rc1,<2.1
+    django20: django>=2.0,<2.1
 
 [testenv:isort]
 commands = isort --check-only --recursive src tests {posargs}


### PR DESCRIPTION
- Add rendering tests
- Fix rendering of html `field.help_text`

Django's form html building does not escape help text, essentially treating it as safe. We should similarly treat it as safe w/ `mark_safe()`. 